### PR TITLE
Rename the "record" message key

### DIFF
--- a/BlueLL.skin.php
+++ b/BlueLL.skin.php
@@ -75,7 +75,7 @@ class BlueLLTemplate extends BaseTemplate {
 						<?php if ( class_exists( 'SpecialRecordWizard' ) ) {?>
 						<li id="p-record">
 							<?php $recordwizardTitle = Title::newFromText( "Special:RecordWizard" ); ?>
-							<?php echo $this->makeLink( "RecordWizard", [ "msg" => "Record", "href" => $recordwizardTitle->getFullURL(), "accesskey" => "r" ] ); ?></a>
+							<?php echo $this->makeLink( "RecordWizard", [ "msg" => "bluell-record", "href" => $recordwizardTitle->getFullURL(), "accesskey" => "r" ] ); ?></a>
 						</li>
 						<?php }?>
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,5 +7,5 @@
 	"skinname-bluell": "BlueLLs",
 	"bluell-desc": "Clean design initially developed for Lingua Libre.",
 	"bluell-menutitle": "Menu",
-	"record": "Record"
+	"bluell-record": "Record"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -7,5 +7,5 @@
 	"skinname-bluell": "BlueLL",
 	"bluell-desc": "Habillage épuré initialement dévelopé pour Lingua Libre.",
 	"bluell-menutitle": "Menu",
-	"record": "Enregistrer"
+	"bluell-record": "Enregistrer"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -7,5 +7,5 @@
 	"skinname-bluell": "{{Notranslate}}\n\nThis this is the name of the skin.",
 	"bluell-desc": "{{desc|what=skin|name=BlueLL|url=https://www.mediawiki.org/wiki/Skin:BlueLL}}",
 	"bluell-menutitle": "This is a label.",
-	"record": "Button to RecordWizard"
+	"bluell-record": "Button to RecordWizard"
 }


### PR DESCRIPTION
Address point number 2 in issue #8.

To make this skin translatable in translatewiki,
the messages keys must be unique and consistently prefixed.
This patch renames the key "record".

See translatewiki task:
https://phabricator.wikimedia.org/T283956