### PR TITLE
Use User::isRegistered() instead of User::isLoggedIn()

### DIFF
--- a/BlueLL.skin.php
+++ b/BlueLL.skin.php
@@ -80,7 +80,7 @@ class BlueLLTemplate extends BaseTemplate {
 						<?php }?>
 
 						<!-- If user is logged in output echo location -->
-						<?php if ($wgUser->isLoggedIn()): ?>
+						<?php if ($wgUser->isRegistered()): ?>
 							<div id="echo-notifications-alerts"></div>
 							<div id="echo-notifications-notice"></div>
 						<?php endif; ?>


### PR DESCRIPTION
User::isLoggedIn() has been deprecated in favor of User::isRegistered() and thus their usages should be replaced.

See https://phabricator.wikimedia.org/T270450