### PR TITLE
Add top menu messages

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1,8 +1,12 @@
 {
 	"@metadata": {
 		"authors": [
-			"Lorem Ipsum"
+			"0x010C",
+			"Lorem Ipsum",
+			"WikiLucas00"
 		]
 	},
+	"bluell-menu-statistics": "Statistiken",
+	"bluell-menu-datasets": "Datensätze",
 	"bluell-menutitle": "Menü"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,11 +1,18 @@
 {
 	"@metadata": {
 		"authors": [
-			"Antoine Lamielle"
+			"0x010C",
+			"Amire80",
+			"Antoine Lamielle",
+			"Trizek",
+			"WikiLucas00"
 		]
 	},
 	"skinname-bluell": "BlueLL",
 	"bluell-desc": "Clean design initially developed for Lingua Libre.",
+	"bluell-menu-statistics": "Statistics",
+	"bluell-menu-library": "Sound library",
+	"bluell-menu-datasets": "Datasets",
 	"bluell-menutitle": "Menu",
 	"bluell-record": "Record"
 }

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -1,0 +1,9 @@
+{
+	"@metadata": {
+		"authors": [
+			"Pamputt"
+		]
+	},
+	"bluell-menu-statistics": "Statistiko",
+	"bluell-menu-datasets": "Datumaro"
+}

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,10 +1,14 @@
 {
 	"@metadata": {
 		"authors": [
-			"Agent"
+			"0x010C",
+			"Agent",
+			"Pamputt"
 		]
 	},
 	"bluell-desc": "Diseño limpio inicialmente desarrollado para Lingua Libre.",
+	"bluell-menu-statistics": "Estadísticas",
+	"bluell-menu-library": "Archivos de datos",
 	"bluell-menutitle": "Menú",
 	"bluell-record": "Grabar"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,10 +1,16 @@
 {
 	"@metadata": {
 		"authors": [
-			"Antoine Lamielle"
+			"0x010C",
+			"Antoine Lamielle",
+			"Trizek",
+			"WikiLucas00"
 		]
 	},
 	"bluell-desc": "Habillage épuré initialement développé pour Lingua Libre.",
+	"bluell-menu-statistics": "Statistiques",
+	"bluell-menu-library": "Sonothèque",
+	"bluell-menu-datasets": "Jeux de données",
 	"bluell-menutitle": "Menu",
 	"bluell-record": "Enregistrer"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -1,9 +1,11 @@
 {
 	"@metadata": {
 		"authors": [
+			"0x010C",
 			"Beta16"
 		]
 	},
+	"bluell-menu-statistics": "Dataset",
 	"bluell-menutitle": "Menu",
 	"bluell-record": "Registra"
 }

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -1,10 +1,13 @@
 {
 	"@metadata": {
 		"authors": [
-			"Bjankuloski06"
+			"Bjankuloski06",
+			"Pamputt"
 		]
 	},
 	"bluell-desc": "Чист изглед првично изработен за Lingua Libre.",
+	"bluell-menu-statistics": "Статистика",
+	"bluell-menu-library": "Звукотека",
 	"bluell-menutitle": "Мени",
 	"bluell-record": "Снимај"
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -1,0 +1,11 @@
+{
+	"@metadata": {
+		"authors": [
+			"Guilhelma",
+			"WikiLucas00"
+		]
+	},
+	"bluell-menu-statistics": "Estatisticas",
+	"bluell-menu-library": "Librariá sonòra",
+	"bluell-menu-datasets": "Jòc de donadas"
+}

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -1,8 +1,11 @@
 {
 	"@metadata": {
 		"authors": [
-			"Rail"
+			"Rail",
+			"Pamputt"
 		]
 	},
 	"bluell-desc": "Czysty design początkowo opracowany przez Lingua Libre"
+	"bluell-menu-statistics": "Statystyki",
+	"bluell-menu-datasets": "Zbiory danych"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -7,6 +7,9 @@
 	},
 	"skinname-bluell": "{{Notranslate}}\n\nThis this is the name of the skin.",
 	"bluell-desc": "{{desc|what=skin|name=BlueLL|url=https://www.mediawiki.org/wiki/Skin:BlueLL}}",
+	"bluell-menu-statistics": "Label for top menu. Leads to the statistics page.",
+	"bluell-menu-library": "Label for top menu. Leads to the library tool.",
+	"bluell-menu-datasets": "Label for top menu. Leads to the list of files with datasets.",
 	"bluell-menutitle": "This is a label.\n{{identical|Menu}}",
 	"bluell-record": "Button to RecordWizard"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -1,10 +1,14 @@
 {
 	"@metadata": {
 		"authors": [
-			"Sabelöga"
+			"Sabelöga",
+			"Pamputt"
 		]
 	},
 	"bluell-desc": "Ren utformning ursprungligen utvecklad för Lingua Libre.",
+	"bluell-menu-statistics": "Statistik",
+	"bluell-menu-library": "Ljudbiblioteket",
+	"bluell-menu-datasets": "Datauppsättningar",
 	"bluell-menutitle": "Meny",
 	"bluell-record": "Spela in"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -1,10 +1,12 @@
 {
 	"@metadata": {
 		"authors": [
-			"Hedda"
+			"WikiLucas00"
 		]
 	},
 	"bluell-desc": "Temiz tasarım esasen Lingua Libre için geliştirildi.",
+	"bluell-menu-statistics": "İstatistikler",
+	"bluell-menu-library": "Ses kütüphanesi",
 	"bluell-menutitle": "Menü",
 	"bluell-record": "Kayıt"
 }


### PR DESCRIPTION
### Probleme
Menu labels should be conveniently localizable, but currently they are manually created by LinguaLibre administrators.

### Solution
I copied all the translations I could in the MediaWiki namespace on lingualibre.org, with credits, into BlueLL's translatable jsons.

### After deploiement
- [MediaWiki:Sidebar] must be edited since prefix have been added
- Local translations must be deleted."