### PR TITLE
Fix stored XSS via MediaWiki:Sidebar

### DIFF
--- a/BlueLL.skin.php
+++ b/BlueLL.skin.php
@@ -86,7 +86,7 @@ class BlueLLTemplate extends BaseTemplate {
 
 					<div id="top-bar-bottom-menu">
 						<?php foreach ( $this->getSidebar() as $boxName => $box ) { if ( $box['header'] != wfMessage( 'toolbox' )->text() && $box['id'] != 'p-lang'  ) { ?>
-							<ul id="<?php echo Sanitizer::escapeIdForAttribute( $box['id'] ) ?>"<?php echo Linker::tooltip( $box['id'] ) ?>>
+							<ul id="<?php echo htmlspecialchars( Sanitizer::escapeIdForAttribute( $box['id'] ), ENT_QUOTES ) ?>"<?php echo Linker::tooltip( $box['id'] ) ?>>
 								<?php if ( is_array( $box['content'] ) ) { ?>
 								<?php foreach ( $box['content'] as $key => $item ) { echo $this->makeListItem( $key, $item ); } ?>
 								<?php } } ?>


### PR DESCRIPTION
BlueLL skin: stored XSS via MediaWiki:Sidebar

Top-level menu entries from MediaWiki:Sidebar are not properly escaped in the BlueLL skin ([Lingua-Libre](https://phabricator.wikimedia.org/tag/lingua-libre/)), resulting in classic stored XSS. The output of Sanitizer::escapeIdForAttribute is not HTML-safe, but the skin incorrectly assumes it is.

Bug: T361453